### PR TITLE
Display country name when a country outline is selected

### DIFF
--- a/www/src/App.vue
+++ b/www/src/App.vue
@@ -7,7 +7,7 @@
         class="py-1 md:py-5"
       />
       <div class="
-      grid mx-auto justify-items-center gap-4 max-w-max
+      grid mx-auto justify-items-center gap-6 max-w-max
       grid-cols-2
       md:grid-cols-4 
       ">

--- a/www/src/components/Country.vue
+++ b/www/src/components/Country.vue
@@ -15,6 +15,9 @@
         :class="[country.cssFilter, hoverCssFilter]"
       >
     </div>
+    <div v-if="selected" class="text-center text-sm font-semibold mt-1">
+      {{ country.name }}
+    </div>
   </div>
 </template>
 
@@ -25,6 +28,7 @@ export default {
     return {
       hoverCssFilter: '',
       animationClass: '',
+      selected: false,
     }
   },
   props: [
@@ -43,6 +47,7 @@ export default {
         chosenCountry.cssFilter = "filter-incorrect";
         this.animationClass = 'animate-shake';
       }
+      this.selected = true;
       this.$forceUpdate();
     },
   },

--- a/www/src/components/Country.vue
+++ b/www/src/components/Country.vue
@@ -15,7 +15,7 @@
         :class="[country.cssFilter, hoverCssFilter]"
       >
     </div>
-    <div class="absolute inset-x-0 top-full text-center text-sm font-semibold h-5 leading-5 truncate">
+    <div class="absolute inset-x-0 top-full text-center text-sm h-5 leading-5 truncate">
       {{ selected ? country.name : '' }}
     </div>
   </div>

--- a/www/src/components/Country.vue
+++ b/www/src/components/Country.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="relative">
     <div
       class="rounded border-2 border-black border-solid"
       :class="animationClass"
@@ -15,7 +15,7 @@
         :class="[country.cssFilter, hoverCssFilter]"
       >
     </div>
-    <div class="text-center text-sm font-semibold mt-1 h-5 leading-5 truncate">
+    <div class="absolute inset-x-0 top-full text-center text-sm font-semibold h-5 leading-5 truncate">
       {{ selected ? country.name : '' }}
     </div>
   </div>

--- a/www/src/components/Country.vue
+++ b/www/src/components/Country.vue
@@ -15,8 +15,8 @@
         :class="[country.cssFilter, hoverCssFilter]"
       >
     </div>
-    <div v-if="selected" class="text-center text-sm font-semibold mt-1">
-      {{ country.name }}
+    <div class="text-center text-sm font-semibold mt-1 h-5 leading-5 truncate">
+      {{ selected ? country.name : '' }}
     </div>
   </div>
 </template>


### PR DESCRIPTION
When a user clicks a country outline, its name now appears below
the tile so players can see which country they chose.

https://claude.ai/code/session_01B9VDWU56hYa2kV5B5MHsqn